### PR TITLE
Add a siteversion.txt URL so we can see which git hash is in production now

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -19,3 +19,6 @@ venv/
 __pycache__/
 # Ignored by the build system
 /setup.cfg
+
+bin/
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 venv/
 .vscode/
+static/siteversion.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+deploy:
+	bin/deploy.sh

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ Run:
 
 ```bash
 $ cd .../ca_visit_tracking
-$ gcloud app deploy .
+$ make deploy
 ```

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,36 +5,49 @@ DIR="$(cd "$(dirname $0)"; pwd)"
 
 # Output an error message and exit with an error code
 error() {
-  echo "$0: ERROR: $1" 1>&2
+  echo -e "\x1b[31m$0: ERROR: $1\x1b[0m" 1>&2
   exit 1
 }
 
 
 # Output an info message
 info() {
-  echo "$0: INFO: $1" 1>&2
+  echo -e "\x1b[33m$0: INFO: $1\x1b[0m" 1>&2
 }
 
 
+# Perform git-related validations
 check_git_status() {
   # Check that we're releasing only what was committed
-  git diff-index --quiet HEAD -- || error "Uncommitted changes"
+  git diff-index --quiet HEAD -- || (git status; error "Uncommitted changes")
 
   # Check that we're on the master branch
-  git
+  branch="$(git rev-parse --abbrev-ref HEAD)"
+  [ "${branch}" == "master" ] || error "Not on master branch (on ${branch})"
 }
 
 
+# Put any validations before deploying here
 validate() {
+  info "Validating..."
   check_git_status
 }
 
 
+# Record the version number so we can access it at runtime
+record_version() {
+  git rev-parse --short HEAD > static/siteversion.txt
+}
+
+
+# Deploy
 deploy() {
-  echo "Deploying..."
+  info "Deploying..."
+  gcloud app deploy .
 }
 
 
 cd "${DIR}/.."
 validate
+record_version
 deploy

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -e
+
+DIR="$(cd "$(dirname $0)"; pwd)"
+
+
+# Output an error message and exit with an error code
+error() {
+  echo "$0: ERROR: $1" 1>&2
+  exit 1
+}
+
+
+# Output an info message
+info() {
+  echo "$0: INFO: $1" 1>&2
+}
+
+
+check_git_status() {
+  # Check that we're releasing only what was committed
+  git diff-index --quiet HEAD -- || error "Uncommitted changes"
+
+  # Check that we're on the master branch
+  git
+}
+
+
+validate() {
+  check_git_status
+}
+
+
+deploy() {
+  echo "Deploying..."
+}
+
+
+cd "${DIR}/.."
+validate
+deploy


### PR DESCRIPTION
Closes #53 

To use, instead of running `gcloud app deploy`, run `make deploy`, which will perform some validations (check that there are no uncommitted changes, check releasing from master) and then write a site version and then deploy.