### PR TITLE
Set Google Maps API Key to appstate["maps_api_key"]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,7 @@ deploy-prod:
 deploy-beta:
 	@echo "Deploying to beta.visitdata.org..."
 	bin/deploy.sh beta
+
+run:
+	@echo "Running locally in development mode..."
+	python main.py

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ VisitData.org needs volunteer programmers, data analysts, and crisis team liaiso
 # Running locally
 To run the app locally, in development mode:
 
+1. Obtain a Google Maps API key. If you do not have one, you can just set it to
+   `""` and the map will be disabled. Note the API key should never be committed
+   to the git repository.
+2. Set up a Python virtualenv, as specified below.
+3. Run the server, as specified below.
+
 ## Set up a Python environment
 To set up a virtual env:
 ```bash
@@ -16,11 +22,14 @@ $ pip install -r requirements.txt
 ```
 
 ## Run server in development mode:
-The development server will automatically refresh when files change:
+To run the server in development mode:
 
 ```bash
-$ python main.py
+$ export MAPS_API_KEY="..."
+$ make run
 ```
+
+The development server will automatically refresh when files change.
 
 # Deploying to the web server
 To deploy the app to visitdata.org:

--- a/main.py
+++ b/main.py
@@ -1,8 +1,20 @@
 # [START gae_python37_app]
+import os
+import sys
+import traceback
+
 from flask import Flask, redirect, render_template
+from google.cloud import storage
 
 
 app = Flask(__name__, static_url_path="", static_folder="static")
+app_state = {
+    "maps_api_key": ""
+}
+
+
+def error(message):
+    print(message, file=sys.stderr)
 
 
 @app.route("/")
@@ -14,47 +26,86 @@ def root():
 def index():
     return render_template("statelist.html")
 
+
 @app.route("/counties/<counties>")
 def bycounties(counties):
     return render_template("index.html", counties=counties, venues="")
+
 
 @app.route("/venues/<venues>")
 def byvenues(venues):
     return render_template("index.html", counties="", venues=venues)
 
+
 @app.route("/bydate.html")
 def bydate():
     return render_template("bydate.html", state="", counties="", venues="")
+
 
 @app.route("/bydatesel/<state>")
 def bydateselstate(state):
     return render_template("bydate.html", state=state, counties="", venues="")
 
+
 @app.route("/bydatesel/<state>/<counties>/<venues>")
 def bydatesel(state, counties, venues):
     return render_template("bydate.html", state=state, counties=counties, venues=venues)
+
 
 @app.route("/allstate.html")
 def bystate():
     return render_template("allstate.html", state="ALL", venues="ALL")
 
+
 @app.route("/bystatesel/<state>")
 def bystateselstate(state):
     return render_template("allstate.html", state=state, venues="")
+
 
 @app.route("/bystatesel/<state>/<venues>")
 def bystatesel(state, venues):
     return render_template("allstate.html", state=state, venues=venues)
 
+
 @app.route("/faq")
 def faq():
     return render_template("faq.html")
 
+
 def page_not_found(e):
     return render_template('404.html'), 404
 
-app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 60
-app.register_error_handler(404, page_not_found)
+
+def _init_maps_api_key():
+    if os.getenv("GAE_ENV", "").startswith("standard"):
+        # Production in the standard environment
+        try:
+            project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+            project_bucket = f"{project_id}.appspot.com"
+            storage_client = storage.Client()
+            bucket = storage_client.bucket(project_bucket)
+            blob = bucket.blob("secrets/maps_api_key")
+            maps_api_key = blob.download_as_string().decode("utf-8").rstrip()
+        except IOError:
+            traceback.print_exc(file=sys.stderr)
+            maps_api_key = ""
+    else:
+        # Local execution.
+        maps_api_key = os.getenv("MAPS_API_KEY", "")
+
+    if maps_api_key == "":
+        error("Could not retrieve API key. Disabling Google Maps API.")
+
+    app_state["maps_api_key"] = maps_api_key
+
+
+def _init():
+    app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 60
+    app.register_error_handler(404, page_not_found)
+    _init_maps_api_key()
+
+
+_init()
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==1.1.1
 gunicorn==19.10.0
+google-cloud-storage==1.27.0


### PR DESCRIPTION
Closes #86 

The Google Maps API is provided to the app in a dict key called `appstate["maps_api_key"]`.

If in developer mode, you set this key using `MAPS_API_KEY="..." make run`. Contact a project administrator for the dev API key and do not commit it to the repo.

In prod mode, the API key is retrieved automatically as a secret from the project bucket.

Tested in beta.